### PR TITLE
Fix Bignum/Integer compatibility

### DIFF
--- a/lib/vagrant-nixos/nix.rb
+++ b/lib/vagrant-nixos/nix.rb
@@ -75,7 +75,7 @@ class String
   end
 end
 
-class Fixnum
+class Integer
   def to_nix(indent = 0)
     to_s
   end


### PR DESCRIPTION
Current vagrants are using Ruby 2.4 which starts emitting deprecation warnings. I guess we should follow.